### PR TITLE
Update publisher command to use message-payload-file flag

### DIFF
--- a/cmd/publisher/main.go
+++ b/cmd/publisher/main.go
@@ -70,15 +70,15 @@ func main() {
 								Required: true,
 							},
 							&cli.StringFlag{
-								Name:     "message-file",
-								Usage:    "Path to the file containing the message to publish",
+								Name:     "message-payload-file",
+								Usage:    "Path to the file containing the message payload to publish",
 								Required: true,
 							},
 						},
 						Action: func(c *cli.Context) error {
 							projectID := c.String("project")
 							topicID := c.String("topic")
-							messageFile := c.String("message-file")
+							messageFile := c.String("message-payload-file")
 							return publishMessage(c.Context, projectID, topicID, messageFile)
 						},
 					},
@@ -138,7 +138,6 @@ func publishMessage(ctx context.Context, projectID string, topicID string, messa
 	return nil
 }
 
-
 func createTopic(ctx context.Context, projectID string, topicID string) error {
 	// Create a publisher client
 	pub, err := publisher.NewPublisher(projectID)
@@ -156,4 +155,3 @@ func createTopic(ctx context.Context, projectID string, topicID string) error {
 	fmt.Printf("Topic created: %s\n", topic.ID())
 	return nil
 }
-


### PR DESCRIPTION
This PR updates the publisher command to use the `message-payload-file` flag instead of `message-file` as requested. The message payload will be read directly from the specified file.

Usage example:
```
pubsub-cli publisher publish --topic=my-topic --project=my-project --message-payload-file=path/to/payload
```