### PR TITLE
Add subscriber subscribe command

### DIFF
--- a/cmd/subscriber/main.go
+++ b/cmd/subscriber/main.go
@@ -1,5 +1,85 @@
 package main
 
-func main() {
+import (
+        "context"
+        "fmt"
+        "log"
+        "os"
+        "os/signal"
+        "syscall"
 
+        "github.com/GarupanOjisan/pubsub-cli/pkg/subscriber"
+        "github.com/urfave/cli/v2"
+)
+
+func main() {
+        app := &cli.App{
+                Name:  "pubsub-cli",
+                Usage: "A CLI for Google Cloud Pub/Sub",
+                Commands: []*cli.Command{
+                        {
+                                Name:  "subscriber",
+                                Usage: "Subscriber commands",
+                                Subcommands: []*cli.Command{
+                                        {
+                                                Name:  "subscribe",
+                                                Usage: "Subscribe to a subscription",
+                                                Flags: []cli.Flag{
+                                                        &cli.StringFlag{
+                                                                Name:     "project",
+                                                                Usage:    "Google Cloud project ID",
+                                                                Required: true,
+                                                        },
+                                                        &cli.StringFlag{
+                                                                Name:     "subscription",
+                                                                Usage:    "Subscription ID to subscribe to",
+                                                                Required: true,
+                                                        },
+                                                        &cli.BoolFlag{
+                                                                Name:  "ack",
+                                                                Usage: "Acknowledge received messages",
+                                                                Value: false,
+                                                        },
+                                                },
+                                                Action: func(c *cli.Context) error {
+                                                        projectID := c.String("project")
+                                                        subscriptionID := c.String("subscription")
+                                                        shouldAck := c.Bool("ack")
+                                                        return subscribeToSubscription(c.Context, projectID, subscriptionID, shouldAck)
+                                                },
+                                        },
+                                },
+                        },
+                },
+        }
+
+        err := app.Run(os.Args)
+        if err != nil {
+                log.Fatal(err)
+        }
+}
+
+func subscribeToSubscription(ctx context.Context, projectID string, subscriptionID string, shouldAck bool) error {
+        // Create a subscriber client
+        sub, err := subscriber.NewSubscriber(projectID)
+        if err != nil {
+                return fmt.Errorf("failed to create subscriber: %v", err)
+        }
+        defer sub.Close()
+
+        // Create a context that can be cancelled with Ctrl+C
+        ctx, cancel := context.WithCancel(ctx)
+        defer cancel()
+
+        // Set up signal handling for graceful shutdown
+        signalCh := make(chan os.Signal, 1)
+        signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
+        go func() {
+                <-signalCh
+                fmt.Println("\nReceived interrupt signal. Shutting down...")
+                cancel()
+        }()
+
+        // Subscribe to the subscription
+        return sub.Subscribe(ctx, subscriptionID, shouldAck, os.Stdout)
 }

--- a/cmd/subscriber/main.go
+++ b/cmd/subscriber/main.go
@@ -1,85 +1,85 @@
 package main
 
 import (
-        "context"
-        "fmt"
-        "log"
-        "os"
-        "os/signal"
-        "syscall"
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
 
-        "github.com/GarupanOjisan/pubsub-cli/pkg/subscriber"
-        "github.com/urfave/cli/v2"
+	"github.com/GarupanOjisan/pubsub-cli/pkg/subscriber"
+	"github.com/urfave/cli/v2"
 )
 
 func main() {
-        app := &cli.App{
-                Name:  "pubsub-cli",
-                Usage: "A CLI for Google Cloud Pub/Sub",
-                Commands: []*cli.Command{
-                        {
-                                Name:  "subscriber",
-                                Usage: "Subscriber commands",
-                                Subcommands: []*cli.Command{
-                                        {
-                                                Name:  "subscribe",
-                                                Usage: "Subscribe to a subscription",
-                                                Flags: []cli.Flag{
-                                                        &cli.StringFlag{
-                                                                Name:     "project",
-                                                                Usage:    "Google Cloud project ID",
-                                                                Required: true,
-                                                        },
-                                                        &cli.StringFlag{
-                                                                Name:     "subscription",
-                                                                Usage:    "Subscription ID to subscribe to",
-                                                                Required: true,
-                                                        },
-                                                        &cli.BoolFlag{
-                                                                Name:  "ack",
-                                                                Usage: "Acknowledge received messages",
-                                                                Value: false,
-                                                        },
-                                                },
-                                                Action: func(c *cli.Context) error {
-                                                        projectID := c.String("project")
-                                                        subscriptionID := c.String("subscription")
-                                                        shouldAck := c.Bool("ack")
-                                                        return subscribeToSubscription(c.Context, projectID, subscriptionID, shouldAck)
-                                                },
-                                        },
-                                },
-                        },
-                },
-        }
+	app := &cli.App{
+		Name:  "pubsub-cli",
+		Usage: "A CLI for Google Cloud Pub/Sub",
+		Commands: []*cli.Command{
+			{
+				Name:  "subscriber",
+				Usage: "Subscriber commands",
+				Subcommands: []*cli.Command{
+					{
+						Name:  "subscribe",
+						Usage: "Subscribe to a subscription",
+						Flags: []cli.Flag{
+							&cli.StringFlag{
+								Name:     "project",
+								Usage:    "Google Cloud project ID",
+								Required: true,
+							},
+							&cli.StringFlag{
+								Name:     "subscription",
+								Usage:    "Subscription ID to subscribe to",
+								Required: true,
+							},
+							&cli.BoolFlag{
+								Name:  "ack",
+								Usage: "Acknowledge received messages",
+								Value: false,
+							},
+						},
+						Action: func(c *cli.Context) error {
+							projectID := c.String("project")
+							subscriptionID := c.String("subscription")
+							shouldAck := c.Bool("ack")
+							return subscribeToSubscription(c.Context, projectID, subscriptionID, shouldAck)
+						},
+					},
+				},
+			},
+		},
+	}
 
-        err := app.Run(os.Args)
-        if err != nil {
-                log.Fatal(err)
-        }
+	err := app.Run(os.Args)
+	if err != nil {
+		log.Fatal(err)
+	}
 }
 
 func subscribeToSubscription(ctx context.Context, projectID string, subscriptionID string, shouldAck bool) error {
-        // Create a subscriber client
-        sub, err := subscriber.NewSubscriber(projectID)
-        if err != nil {
-                return fmt.Errorf("failed to create subscriber: %v", err)
-        }
-        defer sub.Close()
+	// Create a subscriber client
+	sub, err := subscriber.NewSubscriber(projectID)
+	if err != nil {
+		return fmt.Errorf("failed to create subscriber: %v", err)
+	}
+	defer sub.Close()
 
-        // Create a context that can be cancelled with Ctrl+C
-        ctx, cancel := context.WithCancel(ctx)
-        defer cancel()
+	// Create a context that can be cancelled with Ctrl+C
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
-        // Set up signal handling for graceful shutdown
-        signalCh := make(chan os.Signal, 1)
-        signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
-        go func() {
-                <-signalCh
-                fmt.Println("\nReceived interrupt signal. Shutting down...")
-                cancel()
-        }()
+	// Set up signal handling for graceful shutdown
+	signalCh := make(chan os.Signal, 1)
+	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-signalCh
+		fmt.Println("\nReceived interrupt signal. Shutting down...")
+		cancel()
+	}()
 
-        // Subscribe to the subscription
-        return sub.Subscribe(ctx, subscriptionID, shouldAck, os.Stdout)
+	// Subscribe to the subscription
+	return sub.Subscribe(ctx, subscriptionID, shouldAck, os.Stdout)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/GarupanOjisan/pubsub-cli
 
-go 1.23.0
-
-toolchain go1.23.4
+go 1.19
 
 require (
 	cloud.google.com/go/pubsub v1.47.0

--- a/go.sum
+++ b/go.sum
@@ -10,9 +10,7 @@ cloud.google.com/go/compute/metadata v0.6.0/go.mod h1:FjyFAW1MW0C203CEOMDTu3Dk1F
 cloud.google.com/go/iam v1.3.1 h1:KFf8SaT71yYq+sQtRISn90Gyhyf4X8RGgeAVC8XGf3E=
 cloud.google.com/go/iam v1.3.1/go.mod h1:3wMtuyT4NcbnYNPLMBzYRFiEfjKfJlLVLrisE7bwm34=
 cloud.google.com/go/kms v1.20.5 h1:aQQ8esAIVZ1atdJRxihhdxGQ64/zEbJoJnCz/ydSmKg=
-cloud.google.com/go/kms v1.20.5/go.mod h1:C5A8M1sv2YWYy1AE6iSrnddSG9lRGdJq5XEdBy28Lmw=
 cloud.google.com/go/longrunning v0.6.4 h1:3tyw9rO3E2XVXzSApn1gyEEnH2K9SynNQjMlBi3uHLg=
-cloud.google.com/go/longrunning v0.6.4/go.mod h1:ttZpLCe6e7EXvn9OxpBRx7kZEB0efv8yBO6YnVMfhJs=
 cloud.google.com/go/pubsub v1.47.0 h1:Ou2Qu4INnf7ykrFjGv2ntFOjVo8Nloh/+OffF4mUu9w=
 cloud.google.com/go/pubsub v1.47.0/go.mod h1:LaENesmga+2u0nDtLkIOILskxsfvn/BXX9Ak1NFxOs8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -38,7 +36,6 @@ github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
-github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -50,7 +47,6 @@ github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvq
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
-github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -58,7 +54,6 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
-github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/s2a-go v0.1.9 h1:LGD7gtMgezd8a/Xak7mEWL0PjoTQFvpRudN895yqKW0=
 github.com/google/s2a-go v0.1.9/go.mod h1:YA0Ei2ZQL3acow2O62kdp9UlnvMmU7kA6Eutn0dXayM=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -80,13 +75,11 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/urfave/cli/v2 v2.27.5 h1:WoHEJLdsXr6dDWoJgMq/CboDmyY/8HMMH1fTECbih+w=
 github.com/urfave/cli/v2 v2.27.5/go.mod h1:3Sevf16NykTbInEnD0yKkjDAeZDS0A6bzhBH5hrMvTQ=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 go.einride.tech/aip v0.68.1 h1:16/AfSxcQISGN5z9C5lM+0mLYXihrHbQ1onvYTr93aQ=
-go.einride.tech/aip v0.68.1/go.mod h1:XaFtaj4HuA3Zwk9xoBtTWgNubZ0ZZXv9BZJCkuKuWbg=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
@@ -100,9 +93,7 @@ go.opentelemetry.io/otel v1.34.0/go.mod h1:OWFPOQ+h4G8xpyjgqo4SxJYdDQ/qmRH+wivy7
 go.opentelemetry.io/otel/metric v1.34.0 h1:+eTR3U0MyfWjRDhmFMxe2SsW64QrZ84AOhvqS7Y+PoQ=
 go.opentelemetry.io/otel/metric v1.34.0/go.mod h1:CEDrp0fy2D0MvkXE+dPV7cMi8tWZwX3dmaIhwPOaqHE=
 go.opentelemetry.io/otel/sdk v1.34.0 h1:95zS4k/2GOy069d321O8jWgYsW3MzVV+KuSPKp7Wr1A=
-go.opentelemetry.io/otel/sdk v1.34.0/go.mod h1:0e/pNiaMAqaykJGKbi+tSjWfNNHMTxoC9qANsCzbyxU=
 go.opentelemetry.io/otel/sdk/metric v1.32.0 h1:rZvFnvmvawYb0alrYkjraqJq0Z4ZUJAiyYCU9snn1CU=
-go.opentelemetry.io/otel/sdk/metric v1.32.0/go.mod h1:PWeZlq0zt9YkYAp3gjKZ0eicRYvOh1Gd+X99x6GHpCQ=
 go.opentelemetry.io/otel/trace v1.34.0 h1:+ouXS2V8Rd4hp4580a8q23bg0azF2nI8cqLYnC8mh/k=
 go.opentelemetry.io/otel/trace v1.34.0/go.mod h1:Svm7lSjQD7kG7KJ/MUHPVXSDGz2OX4h0M2jHBhmSfRE=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/pkg/subscriber/subscriber.go
+++ b/pkg/subscriber/subscriber.go
@@ -1,8 +1,88 @@
 package subscriber
 
+import (
+        "context"
+        "fmt"
+        "io"
+        "sync"
+
+        "cloud.google.com/go/pubsub"
+)
+
 type Subscriber struct {
+        client *pubsub.Client
 }
 
-func NewSubscriber() *Subscriber {
-	return &Subscriber{}
+func NewSubscriber(projectID string) (*Subscriber, error) {
+        ctx := context.Background()
+        client, err := pubsub.NewClient(ctx, projectID)
+        if err != nil {
+                return nil, fmt.Errorf("pubsub.NewClient: %v", err)
+        }
+        return &Subscriber{
+                client: client,
+        }, nil
+}
+
+func (s *Subscriber) Close() error {
+        return s.client.Close()
+}
+
+func (s *Subscriber) Subscribe(ctx context.Context, subscriptionID string, shouldAck bool, output io.Writer) error {
+        // Check if the subscription exists
+        sub := s.client.Subscription(subscriptionID)
+        exists, err := sub.Exists(ctx)
+        if err != nil {
+                return fmt.Errorf("failed to check if subscription exists: %v", err)
+        }
+        if !exists {
+                return fmt.Errorf("subscription %s does not exist", subscriptionID)
+        }
+
+        // Create a channel to handle errors
+        errCh := make(chan error, 1)
+        var wg sync.WaitGroup
+        wg.Add(1)
+
+        // Start receiving messages
+        fmt.Fprintf(output, "Listening for messages on subscription %s...\n", subscriptionID)
+        fmt.Fprintf(output, "Press Ctrl+C to exit\n\n")
+
+        go func() {
+                defer wg.Done()
+                err := sub.Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
+                        fmt.Fprintf(output, "Received message: ID=%s\n", msg.ID)
+                        fmt.Fprintf(output, "Data: %s\n", string(msg.Data))
+                        
+                        if len(msg.Attributes) > 0 {
+                                fmt.Fprintf(output, "Attributes:\n")
+                                for key, value := range msg.Attributes {
+                                        fmt.Fprintf(output, "  %s: %s\n", key, value)
+                                }
+                        }
+                        
+                        fmt.Fprintf(output, "PublishTime: %v\n\n", msg.PublishTime)
+                        
+                        if shouldAck {
+                                msg.Ack()
+                                fmt.Fprintf(output, "Message acknowledged: ID=%s\n\n", msg.ID)
+                        } else {
+                                fmt.Fprintf(output, "Message not acknowledged (--ack flag not provided)\n\n")
+                        }
+                })
+                if err != nil {
+                        errCh <- fmt.Errorf("receive error: %v", err)
+                }
+        }()
+
+        // Wait for context cancellation or error
+        select {
+        case <-ctx.Done():
+                fmt.Fprintf(output, "\nSubscription stopped: %v\n", ctx.Err())
+        case err := <-errCh:
+                return err
+        }
+
+        wg.Wait()
+        return nil
 }

--- a/pkg/subscriber/subscriber.go
+++ b/pkg/subscriber/subscriber.go
@@ -1,88 +1,88 @@
 package subscriber
 
 import (
-        "context"
-        "fmt"
-        "io"
-        "sync"
+	"context"
+	"fmt"
+	"io"
+	"sync"
 
-        "cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub"
 )
 
 type Subscriber struct {
-        client *pubsub.Client
+	client *pubsub.Client
 }
 
 func NewSubscriber(projectID string) (*Subscriber, error) {
-        ctx := context.Background()
-        client, err := pubsub.NewClient(ctx, projectID)
-        if err != nil {
-                return nil, fmt.Errorf("pubsub.NewClient: %v", err)
-        }
-        return &Subscriber{
-                client: client,
-        }, nil
+	ctx := context.Background()
+	client, err := pubsub.NewClient(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("pubsub.NewClient: %v", err)
+	}
+	return &Subscriber{
+		client: client,
+	}, nil
 }
 
 func (s *Subscriber) Close() error {
-        return s.client.Close()
+	return s.client.Close()
 }
 
 func (s *Subscriber) Subscribe(ctx context.Context, subscriptionID string, shouldAck bool, output io.Writer) error {
-        // Check if the subscription exists
-        sub := s.client.Subscription(subscriptionID)
-        exists, err := sub.Exists(ctx)
-        if err != nil {
-                return fmt.Errorf("failed to check if subscription exists: %v", err)
-        }
-        if !exists {
-                return fmt.Errorf("subscription %s does not exist", subscriptionID)
-        }
+	// Check if the subscription exists
+	sub := s.client.Subscription(subscriptionID)
+	exists, err := sub.Exists(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to check if subscription exists: %v", err)
+	}
+	if !exists {
+		return fmt.Errorf("subscription %s does not exist", subscriptionID)
+	}
 
-        // Create a channel to handle errors
-        errCh := make(chan error, 1)
-        var wg sync.WaitGroup
-        wg.Add(1)
+	// Create a channel to handle errors
+	errCh := make(chan error, 1)
+	var wg sync.WaitGroup
+	wg.Add(1)
 
-        // Start receiving messages
-        fmt.Fprintf(output, "Listening for messages on subscription %s...\n", subscriptionID)
-        fmt.Fprintf(output, "Press Ctrl+C to exit\n\n")
+	// Start receiving messages
+	fmt.Fprintf(output, "Listening for messages on subscription %s...\n", subscriptionID)
+	fmt.Fprintf(output, "Press Ctrl+C to exit\n\n")
 
-        go func() {
-                defer wg.Done()
-                err := sub.Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
-                        fmt.Fprintf(output, "Received message: ID=%s\n", msg.ID)
-                        fmt.Fprintf(output, "Data: %s\n", string(msg.Data))
-                        
-                        if len(msg.Attributes) > 0 {
-                                fmt.Fprintf(output, "Attributes:\n")
-                                for key, value := range msg.Attributes {
-                                        fmt.Fprintf(output, "  %s: %s\n", key, value)
-                                }
-                        }
-                        
-                        fmt.Fprintf(output, "PublishTime: %v\n\n", msg.PublishTime)
-                        
-                        if shouldAck {
-                                msg.Ack()
-                                fmt.Fprintf(output, "Message acknowledged: ID=%s\n\n", msg.ID)
-                        } else {
-                                fmt.Fprintf(output, "Message not acknowledged (--ack flag not provided)\n\n")
-                        }
-                })
-                if err != nil {
-                        errCh <- fmt.Errorf("receive error: %v", err)
-                }
-        }()
+	go func() {
+		defer wg.Done()
+		err := sub.Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
+			fmt.Fprintf(output, "Received message: ID=%s\n", msg.ID)
+			fmt.Fprintf(output, "Data: %s\n", string(msg.Data))
 
-        // Wait for context cancellation or error
-        select {
-        case <-ctx.Done():
-                fmt.Fprintf(output, "\nSubscription stopped: %v\n", ctx.Err())
-        case err := <-errCh:
-                return err
-        }
+			if len(msg.Attributes) > 0 {
+				fmt.Fprintf(output, "Attributes:\n")
+				for key, value := range msg.Attributes {
+					fmt.Fprintf(output, "  %s: %s\n", key, value)
+				}
+			}
 
-        wg.Wait()
-        return nil
+			fmt.Fprintf(output, "PublishTime: %v\n\n", msg.PublishTime)
+
+			if shouldAck {
+				msg.Ack()
+				fmt.Fprintf(output, "Message acknowledged: ID=%s\n\n", msg.ID)
+			} else {
+				fmt.Fprintf(output, "Message not acknowledged (--ack flag not provided)\n\n")
+			}
+		})
+		if err != nil {
+			errCh <- fmt.Errorf("receive error: %v", err)
+		}
+	}()
+
+	// Wait for context cancellation or error
+	select {
+	case <-ctx.Done():
+		fmt.Fprintf(output, "\nSubscription stopped: %v\n", ctx.Err())
+	case err := <-errCh:
+		return err
+	}
+
+	wg.Wait()
+	return nil
 }


### PR DESCRIPTION
## 概要
subscriberコマンドにsubscribeサブコマンドを実装しました。

## 機能
- `--project`と`--subscription`フラグで対象のプロジェクトとサブスクリプションを指定
- `--ack`フラグを指定した場合は、受信したメッセージを自動的に確認応答（ACK）
- `--ack`フラグを指定しない場合は、メッセージを確認応答せずに表示するだけ

## 使用例
```
pubsub-cli subscriber subscribe --project=my-project --subscription=my-topic-sub --ack
```